### PR TITLE
HW05 is completed

### DIFF
--- a/hw05_parallel_execution/go.mod
+++ b/hw05_parallel_execution/go.mod
@@ -1,4 +1,4 @@
-module github.com/fixme_my_friend/hw05_parallel_execution
+module github.com/AndreiGoStorm/go-home-work/hw05_parallel_execution
 
 go 1.22
 

--- a/hw05_parallel_execution/run.go
+++ b/hw05_parallel_execution/run.go
@@ -2,14 +2,57 @@ package hw05parallelexecution
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 )
 
 var ErrErrorsLimitExceeded = errors.New("errors limit exceeded")
 
 type Task func() error
 
-// Run starts tasks in n goroutines and stops its work when receiving m errors from tasks.
+type WorkerError struct {
+	limitError int32
+	error      error
+	sync.Once
+}
+
 func Run(tasks []Task, n, m int) error {
-	// Place your code here.
-	return nil
+	toProcess := make(chan Task, len(tasks))
+	go process(tasks, toProcess)
+
+	workerError := &WorkerError{limitError: int32(m), error: nil}
+	wg := &sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			worker(workerError, toProcess)
+		}()
+	}
+	wg.Wait()
+
+	return workerError.error
+}
+
+func worker(workerError *WorkerError, toProcess <-chan Task) {
+	for task := range toProcess {
+		limitError := atomic.LoadInt32(&workerError.limitError)
+		if limitError <= 0 {
+			workerError.Do(func() {
+				workerError.error = ErrErrorsLimitExceeded
+			})
+			return
+		}
+		err := task()
+		if err != nil {
+			atomic.AddInt32(&workerError.limitError, -1)
+		}
+	}
+}
+
+func process(tasks []Task, toProcess chan<- Task) {
+	for i := 0; i < len(tasks); i++ {
+		toProcess <- tasks[i]
+	}
+	close(toProcess)
 }

--- a/hw05_parallel_execution/run_test.go
+++ b/hw05_parallel_execution/run_test.go
@@ -67,4 +67,52 @@ func TestRun(t *testing.T) {
 		require.Equal(t, runTasksCount, int32(tasksCount), "not all tasks were completed")
 		require.LessOrEqual(t, int64(elapsedTime), int64(sumTime/2), "tasks were run sequentially?")
 	})
+
+	t.Run("if maxErrorsCount was zero, than finished zero tasks", func(t *testing.T) {
+		tasksCount := 5
+		tasks := make([]Task, 0, tasksCount)
+		var runTasksCount int32
+
+		for i := 0; i < tasksCount; i++ {
+			err := fmt.Errorf("error from task %d", i)
+			tasks = append(tasks, func() error {
+				time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+				atomic.AddInt32(&runTasksCount, 1)
+				return err
+			})
+		}
+
+		workersCount := 2
+		maxErrorsCount := 0
+		err := Run(tasks, workersCount, maxErrorsCount)
+
+		require.Truef(t, errors.Is(err, ErrErrorsLimitExceeded), "actual err - %v", err)
+		require.LessOrEqual(t, runTasksCount, int32(0), "extra tasks were started")
+	})
+
+	t.Run("test without time.Sleep", func(t *testing.T) {
+		tasksCount := 100
+		tasks := make([]Task, 0, tasksCount)
+
+		var runTasksCount int32
+		tasks = append(tasks, func() error {
+			atomic.AddInt32(&runTasksCount, 1)
+			return fmt.Errorf("error from task")
+		})
+		for len(tasks) < tasksCount {
+			tasks = append(tasks, func() error {
+				atomic.AddInt32(&runTasksCount, 1)
+				return nil
+			})
+		}
+
+		workersCount := 10
+		maxErrorsCount := 2
+		err := Run(tasks, workersCount, maxErrorsCount)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			return runTasksCount == int32(tasksCount)
+		}, time.Second, 10*time.Millisecond)
+	})
 }


### PR DESCRIPTION
## Домашнее задание №5 «Параллельное исполнение»
Необходимо написать функцию для параллельного выполнения заданий в n параллельных горутинах:
* количество создаваемых горутин не должно зависеть от числа заданий, т.е. функция должна запускать n горутин для конкурентной обработки заданий и, возможно, еще несколько вспомогательных горутин;
* функция должна останавливать свою работу, если произошло m ошибок;
* после завершения работы функции (успешного или из-за превышения m) не должно оставаться работающих горутин.

Нужно учесть, что задания могут выполняться разное время, а длина списка задач
`len(tasks)` может быть больше или меньше n.

Значение m <= 0 трактуется на усмотрение программиста:
- или это знак игнорировать ошибки в принципе;
- или считать это как "максимум 0 ошибок", значит функция всегда будет возвращать
`ErrErrorsLimitExceeded`;
- на эту логику следует написать юнит-тест.

Граничные случаи:
* если задачи работают без ошибок, то выполнятся `len(tasks)` задач, т.е. все задачи;
* если в первых выполненных m задачах (или вообще всех) происходят ошибки, то всего выполнится не более n+m задач.


**(*) Дополнительное задание: написать тест на concurrency без time.Sleep**

Придумайте тест, который проверит concurrency другим способом.

Текущий тест "tasks without errors" использует time.Sleep и подсчет времени выполнения, чтобы сделать вывод о конкурентности использования. Проблема тестов на слипчиках в том, что на CI часто не хватает CPU и подобные тесты работают нестабильно.

Подсказка: используйте `require.Eventually`.

---
#### Пример
Имеем 10 задач, n=4 воркера, m=2 ошибки.
- Запускаем:
```
--------------ok (узнал, что лимит превышен и остановился)
-----------err
-------err
--------------------ok
```
Выполнится 4 задачи (2 успешно) <= 4 + 2, остальные задачи  не берем.

- Другая ситуация, работающие воркеры успели еще взять задач:
```
------ok--------ok (узнал, что лимит превышен и остановился)
-----------err
---err
--------ok-------ok
```
Выполнится 6 задач (4 успешно) <= 4 + 2, остальные задачи не берем.

- Ошибок не было:
```
-------ok-----ok-----ok-----ok  (1 воркер выполнил 4 задачи)
-----------ok-------------ok    (2 воркер выполнил 2 задачи)
-----ok---------ok---------ok   (3 воркер выполнил 3 задачи)
--------------------ok          (4 воркер выполнил 1 задачу)
```
Выполнится 10 задач (10 успешно): задач не осталось, воркеры остановились.

---

При необходимости можно выделять дополнительные функции / ошибки.

### Критерии оценки
- Пайплайн зелёный - 4 балла
- Добавлены новые юнит-тесты - до 4 баллов
- Понятность и чистота кода - до 2 баллов

#### Зачёт от 7 баллов

### Подсказки
- https://en.wikipedia.org/wiki/Producer%E2%80%93consumer_problem
- `sync.WaitGroup`
- `go test -v -race -count=100 .`

### Частые ошибки
1) `racedetector` ругается на строчку с ассертом в тестах:
- простой случай: после выхода из `Run` остаются висячие горутины, отсюда и получаем `data race` -
ассерт в тестах неатомарно обращается к `runTasksCount`, в то время как зомби-горутины атомарно пытаюся её поменять.
- случай посложнее: один тест завершается успешно, но висячие горутины, им порожденные, аффектят ассерты в
последующих тестах.
2) Запускаются лишние горутины (инструкции `go`). Их количество за все время работы `Run` должно быть n (плюс, возможно, еще одна-две, если по другому не получается). В некоторых решениях ошибочно контроллируется количество одновременно работающих, а не общее количество.

**Решение**: внимательно посмотреть места выхода из функции и гарантировать, что все порождённые вами горутины
завершились к этому моменту.
