### PR TITLE
HW09 is completed

### DIFF
--- a/hw09_struct_validator/go.mod
+++ b/hw09_struct_validator/go.mod
@@ -1,3 +1,11 @@
-module github.com/fixme_my_friend/hw09_struct_validator
+module github.com/AndreiGoStorm/go-home-work/hw09_struct_validator
 
 go 1.22
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/hw09_struct_validator/go.sum
+++ b/hw09_struct_validator/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hw09_struct_validator/govalidator.go
+++ b/hw09_struct_validator/govalidator.go
@@ -1,0 +1,76 @@
+package hw09structvalidator
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var (
+	ErrValidationParse = errors.New("parsing error in field")
+	ErrUndefinedRule   = errors.New("undefined rule in field")
+)
+
+type iValidator interface {
+	validate(v *Validator)
+}
+
+type Validator struct {
+	iValidator iValidator
+	tags       []string
+	value      reflect.Value
+	field      string
+	errs       ValidationErrors
+}
+
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+func (v *Validator) SetFields(tag, field string, value reflect.Value) {
+	v.tags = strings.Split(tag, "|")
+	v.field = field
+	v.value = value
+}
+
+func (v *Validator) SetReflectValue(value reflect.Value) {
+	v.value = value
+}
+
+func (v *Validator) SetIValidator(i iValidator) {
+	v.iValidator = i
+}
+
+func (v *Validator) SetStringValidator() {
+	v.SetIValidator(&StringValidator{})
+}
+
+func (v *Validator) SetIntegerValidator() {
+	v.SetIValidator(&IntegerValidator{})
+}
+
+func (v *Validator) Validate() {
+	v.iValidator.validate(v)
+}
+
+func (v *Validator) parseTag(tag string) []string {
+	args := strings.Split(tag, ":")
+	if len(args) < 2 {
+		v.addValidationError(fmt.Errorf("%w: %s, for tag: %s", ErrValidationParse, v.field, tag))
+		return nil
+	}
+
+	return args
+}
+
+func (v *Validator) addValidationError(err error) {
+	v.errs = append(v.errs, ValidationError{v.field, err})
+}
+
+func (v *Validator) wrapErrors(errs error) {
+	var validationErrs ValidationErrors
+	if errors.As(errs, &validationErrs) {
+		v.errs = append(v.errs, validationErrs...)
+	}
+}

--- a/hw09_struct_validator/govalidator.go
+++ b/hw09_struct_validator/govalidator.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	ErrValidationParse = errors.New("parsing error in field")
-	ErrUndefinedRule   = errors.New("undefined rule in field")
+	ErrFailWrongArgs = errors.New("wrong arguments in field")
+	ErrFailWrongRule = errors.New("wrong rule in field")
 )
 
 type iValidator interface {
-	validate(v *Validator)
+	validate(v *Validator) error
 }
 
 type Validator struct {
@@ -50,27 +50,26 @@ func (v *Validator) SetIntegerValidator() {
 	v.SetIValidator(&IntegerValidator{})
 }
 
-func (v *Validator) Validate() {
-	v.iValidator.validate(v)
+func (v *Validator) Validate() error {
+	return v.iValidator.validate(v)
 }
 
-func (v *Validator) parseTag(tag string) []string {
+func (v *Validator) parseTag(tag string) ([]string, error) {
 	args := strings.Split(tag, ":")
 	if len(args) < 2 {
-		v.addValidationError(fmt.Errorf("%w: %s, for tag: %s", ErrValidationParse, v.field, tag))
-		return nil
+		return nil, fmt.Errorf("%w: %s, for tag: %s", ErrFailWrongArgs, v.field, tag)
 	}
 
-	return args
+	return args, nil
 }
 
 func (v *Validator) addValidationError(err error) {
 	v.errs = append(v.errs, ValidationError{v.field, err})
 }
 
-func (v *Validator) wrapErrors(errs error) {
+func (v *Validator) wrapErrors(err error) {
 	var validationErrs ValidationErrors
-	if errors.As(errs, &validationErrs) {
+	if errors.As(err, &validationErrs) {
 		v.errs = append(v.errs, validationErrs...)
 	}
 }

--- a/hw09_struct_validator/integer_validator.go
+++ b/hw09_struct_validator/integer_validator.go
@@ -1,0 +1,89 @@
+package hw09structvalidator
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrIntMinNumber        = errors.New("value for min is not a number")
+	ErrIntLessThanMin      = errors.New("less than minimum")
+	ErrIntMaxNumber        = errors.New("value for max is not a number")
+	ErrIntMoreThanMax      = errors.New("more than maximum")
+	ErrIntSetNumber        = errors.New("value for in is not a number")
+	ErrIntNotIncludedInSet = errors.New("not included in validation set")
+)
+
+type IntegerValidator struct {
+	v     *Validator
+	value int64
+}
+
+func (iv *IntegerValidator) prepareParams(v *Validator) {
+	iv.v = v
+	iv.value = v.value.Int()
+}
+
+func (iv *IntegerValidator) validate(v *Validator) {
+	iv.prepareParams(v)
+	for _, tag := range v.tags {
+		args := v.parseTag(tag)
+		if args == nil {
+			return
+		}
+
+		switch args[0] {
+		case "min":
+			iv.Min(args[1])
+		case "max":
+			iv.Max(args[1])
+		case "in":
+			iv.In(args[1])
+		default:
+			iv.v.addValidationError(fmt.Errorf("%w: %s, for tag: %s", ErrUndefinedRule, v.field, tag))
+		}
+	}
+}
+
+func (iv *IntegerValidator) Min(arg string) {
+	condition, err := strconv.Atoi(arg)
+	if err != nil {
+		iv.v.addValidationError(ErrIntMinNumber)
+		return
+	}
+	if int64(condition) > iv.value {
+		iv.v.addValidationError(fmt.Errorf("%w: condition %d, value %d", ErrIntLessThanMin, condition, iv.value))
+	}
+}
+
+func (iv *IntegerValidator) Max(arg string) {
+	condition, err := strconv.Atoi(arg)
+	if err != nil {
+		iv.v.addValidationError(ErrIntMaxNumber)
+		return
+	}
+	if int64(condition) < iv.value {
+		iv.v.addValidationError(fmt.Errorf("%w: condition %d, value %d", ErrIntMoreThanMax, condition, iv.value))
+	}
+}
+
+func (iv *IntegerValidator) In(arg string) {
+	set := strings.Split(arg, ",")
+	inSet := false
+	for _, s := range set {
+		intVal, err := strconv.Atoi(s)
+		if err != nil {
+			iv.v.addValidationError(ErrIntSetNumber)
+			return
+		}
+		if int64(intVal) == iv.value {
+			inSet = true
+			break
+		}
+	}
+	if !inSet {
+		iv.v.addValidationError(fmt.Errorf("%w: value %d, set %v", ErrIntNotIncludedInSet, iv.value, set))
+	}
+}

--- a/hw09_struct_validator/string_validator.go
+++ b/hw09_struct_validator/string_validator.go
@@ -1,0 +1,85 @@
+package hw09structvalidator
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrStringLengthNumber     = errors.New("value for length is not a number")
+	ErrStringLength           = errors.New("length of string is wrong")
+	ErrStringRegexp           = errors.New("regexp is wrong")
+	ErrStringNotMatchedRegexp = errors.New("string is not matched regexp")
+	ErrStringNotIncludedSet   = errors.New("string is not included in set")
+)
+
+type StringValidator struct {
+	v     *Validator
+	value string
+}
+
+func (sv *StringValidator) prepareParams(v *Validator) {
+	sv.v = v
+	sv.value = v.value.String()
+}
+
+func (sv *StringValidator) validate(v *Validator) {
+	sv.prepareParams(v)
+	for _, tag := range v.tags {
+		args := v.parseTag(tag)
+		if args == nil {
+			return
+		}
+
+		switch args[0] {
+		case "len":
+			sv.Len(args[1])
+		case "regexp":
+			sv.Regexp(args[1])
+		case "in":
+			sv.In(args[1])
+		default:
+			sv.v.addValidationError(fmt.Errorf("%w: %s, for tag: %s", ErrUndefinedRule, v.field, tag))
+		}
+	}
+}
+
+func (sv *StringValidator) Len(arg string) {
+	condition, err := strconv.Atoi(arg)
+	if err != nil {
+		sv.v.addValidationError(ErrStringLengthNumber)
+		return
+	}
+	if condition != len(sv.value) {
+		sv.v.addValidationError(fmt.Errorf("%w: need %d, have %d", ErrStringLength, condition, len(sv.value)))
+	}
+}
+
+func (sv *StringValidator) Regexp(arg string) {
+	r, err := regexp.Compile(arg)
+	if err != nil {
+		sv.v.addValidationError(ErrStringRegexp)
+		return
+	}
+	matched := r.MatchString(sv.value)
+	if !matched {
+		sv.v.addValidationError(fmt.Errorf("%w: %s", ErrStringNotMatchedRegexp, arg))
+	}
+}
+
+func (sv *StringValidator) In(arg string) {
+	set := strings.Split(arg, ",")
+	in := false
+	for _, s := range set {
+		if s == sv.value {
+			in = true
+			break
+		}
+	}
+	if !in {
+		sv.v.addValidationError(fmt.Errorf("%w: value %s, set %v", ErrStringNotIncludedSet, sv.value, set))
+	}
+}

--- a/hw09_struct_validator/string_validator.go
+++ b/hw09_struct_validator/string_validator.go
@@ -9,9 +9,13 @@ import (
 )
 
 var (
-	ErrStringLengthNumber     = errors.New("value for length is not a number")
+	ErrFailWrongLengthNumber = errors.New("value for length is not a number")
+	ErrFailWrongRegexp       = errors.New("regexp is wrong")
+	ErrFailWrongSet          = errors.New("wrong parameter for in")
+)
+
+var (
 	ErrStringLength           = errors.New("length of string is wrong")
-	ErrStringRegexp           = errors.New("regexp is wrong")
 	ErrStringNotMatchedRegexp = errors.New("string is not matched regexp")
 	ErrStringNotIncludedSet   = errors.New("string is not included in set")
 )
@@ -26,51 +30,57 @@ func (sv *StringValidator) prepareParams(v *Validator) {
 	sv.value = v.value.String()
 }
 
-func (sv *StringValidator) validate(v *Validator) {
+func (sv *StringValidator) validate(v *Validator) error {
 	sv.prepareParams(v)
 	for _, tag := range v.tags {
-		args := v.parseTag(tag)
-		if args == nil {
-			return
+		args, err := v.parseTag(tag)
+		if err != nil {
+			return err
 		}
-
 		switch args[0] {
 		case "len":
-			sv.Len(args[1])
+			err = sv.Len(args[1])
 		case "regexp":
-			sv.Regexp(args[1])
+			err = sv.Regexp(args[1])
 		case "in":
-			sv.In(args[1])
+			err = sv.In(args[1])
 		default:
-			sv.v.addValidationError(fmt.Errorf("%w: %s, for tag: %s", ErrUndefinedRule, v.field, tag))
+			return fmt.Errorf("%w: %s, for tag: %s", ErrFailWrongRule, v.field, tag)
+		}
+		if err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
-func (sv *StringValidator) Len(arg string) {
+func (sv *StringValidator) Len(arg string) error {
 	condition, err := strconv.Atoi(arg)
 	if err != nil {
-		sv.v.addValidationError(ErrStringLengthNumber)
-		return
+		return ErrFailWrongLengthNumber
 	}
 	if condition != len(sv.value) {
 		sv.v.addValidationError(fmt.Errorf("%w: need %d, have %d", ErrStringLength, condition, len(sv.value)))
 	}
+	return nil
 }
 
-func (sv *StringValidator) Regexp(arg string) {
+func (sv *StringValidator) Regexp(arg string) error {
 	r, err := regexp.Compile(arg)
 	if err != nil {
-		sv.v.addValidationError(ErrStringRegexp)
-		return
+		return ErrFailWrongRegexp
 	}
 	matched := r.MatchString(sv.value)
 	if !matched {
 		sv.v.addValidationError(fmt.Errorf("%w: %s", ErrStringNotMatchedRegexp, arg))
 	}
+	return nil
 }
 
-func (sv *StringValidator) In(arg string) {
+func (sv *StringValidator) In(arg string) error {
+	if len(arg) == 0 {
+		return ErrFailWrongSet
+	}
 	set := strings.Split(arg, ",")
 	in := false
 	for _, s := range set {
@@ -82,4 +92,5 @@ func (sv *StringValidator) In(arg string) {
 	if !in {
 		sv.v.addValidationError(fmt.Errorf("%w: value %s, set %v", ErrStringNotIncludedSet, sv.value, set))
 	}
+	return nil
 }

--- a/hw09_struct_validator/validator.go
+++ b/hw09_struct_validator/validator.go
@@ -1,5 +1,11 @@
 package hw09structvalidator
 
+import (
+	"errors"
+	"reflect"
+	"strings"
+)
+
 type ValidationError struct {
 	Field string
 	Err   error
@@ -8,10 +14,81 @@ type ValidationError struct {
 type ValidationErrors []ValidationError
 
 func (v ValidationErrors) Error() string {
-	panic("implement me")
+	var builder strings.Builder
+	for index, err := range v {
+		builder.WriteString("Error in field `")
+		builder.WriteString(err.Field)
+		builder.WriteString("` ")
+		builder.WriteString(err.Err.Error())
+		builder.WriteString(".")
+		if index != len(v)-1 {
+			builder.WriteString(" ")
+		}
+	}
+	return builder.String()
 }
 
+var (
+	ErrNotStruct        = errors.New("input interface is not a struct")
+	ErrNotSupportedType = errors.New("validator unsupported type")
+)
+
 func Validate(v interface{}) error {
-	// Place your code here.
+	value := reflect.ValueOf(v)
+	if value.Kind() != reflect.Struct {
+		return ErrNotStruct
+	}
+
+	validator := NewValidator()
+	valueType := value.Type()
+	for i := 0; i < valueType.NumField(); i++ {
+		field := valueType.Field(i)
+		tag := field.Tag.Get("validate")
+		if len(tag) == 0 {
+			continue
+		}
+
+		fieldValue := value.Field(i)
+		if !fieldValue.CanInterface() {
+			continue
+		}
+
+		validator.SetFields(tag, field.Name, fieldValue)
+		switch fieldValue.Kind() { //nolint:exhaustive
+		case reflect.String:
+			validator.SetStringValidator()
+			validator.Validate()
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			validator.SetIntegerValidator()
+			validator.Validate()
+		case reflect.Slice:
+			switch fieldValue.Type().String() {
+			case "[]string":
+				validator.SetStringValidator()
+				validateSlices(validator, fieldValue)
+			case "[]int", "[]int8", "[]int16", "[]in32", "[]int64":
+				validator.SetIntegerValidator()
+				validateSlices(validator, fieldValue)
+			}
+		case reflect.Struct:
+			if tag == "nested" {
+				errs := Validate(fieldValue.Interface())
+				validator.wrapErrors(errs)
+			}
+		default:
+			return ErrNotSupportedType
+		}
+	}
+
+	if len(validator.errs) > 0 {
+		return validator.errs
+	}
 	return nil
+}
+
+func validateSlices(validator *Validator, fieldValue reflect.Value) {
+	for i := 0; i < fieldValue.Len(); i++ {
+		validator.SetReflectValue(fieldValue.Index(i))
+		validator.Validate()
+	}
 }

--- a/hw09_struct_validator/validator_test.go
+++ b/hw09_struct_validator/validator_test.go
@@ -2,8 +2,11 @@ package hw09structvalidator
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type UserRole string
@@ -13,11 +16,11 @@ type (
 	User struct {
 		ID     string `json:"id" validate:"len:36"`
 		Name   string
-		Age    int             `validate:"min:18|max:50"`
-		Email  string          `validate:"regexp:^\\w+@\\w+\\.\\w+$"`
-		Role   UserRole        `validate:"in:admin,stuff"`
-		Phones []string        `validate:"len:11"`
-		meta   json.RawMessage //nolint:unused
+		Age    int      `validate:"min:18|max:50"`
+		Email  string   `validate:"regexp:^\\w+@\\w+\\.\\w+$"`
+		Role   UserRole `validate:"in:admin,stuff"`
+		Phones []string `validate:"len:11"`
+		meta   json.RawMessage
 	}
 
 	App struct {
@@ -34,6 +37,26 @@ type (
 		Code int    `validate:"in:200,404,500"`
 		Body string `json:"omitempty"`
 	}
+
+	UserProfile struct {
+		ID       string   `json:"id" validate:"len:36"`
+		UserInfo UserInfo `validate:"nested"`
+		Identity int64    `validate:"min:1"`
+	}
+
+	Role struct {
+		ID   int64  `validate:"min:1"`
+		Name string `validate:"regexp:^\\w+$"`
+		Ref  string
+		UUID string `validate:"len:36"`
+	}
+
+	UserInfo struct {
+		ID     int64  `validate:"min:1"`
+		Role   Role   `validate:"nested"`
+		Age    int    `validate:"min:18|max:50"`
+		Phones string `validate:"len:11"`
+	}
 )
 
 func TestValidate(t *testing.T) {
@@ -42,10 +65,36 @@ func TestValidate(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			// Place your code here.
+			User{
+				ID:     "b95b6a96-588a-4fcb-b169-0632a2c5bfc5",
+				Name:   "Andrei",
+				Age:    18,
+				Email:  "andrei@example.com",
+				Role:   "admin",
+				Phones: []string{"57631726972", "42745657177"},
+				meta:   nil,
+			},
+			nil,
 		},
-		// ...
-		// Place your code here.
+		{
+			App{"2.3.4"},
+			nil,
+		},
+		{
+			Token{
+				Header:    []byte("header"),
+				Payload:   []byte("payload"),
+				Signature: []byte("signature"),
+			},
+			nil,
+		},
+		{
+			Response{
+				Code: 200,
+				Body: "{body}",
+			},
+			nil,
+		},
 	}
 
 	for i, tt := range tests {
@@ -53,8 +102,197 @@ func TestValidate(t *testing.T) {
 			tt := tt
 			t.Parallel()
 
-			// Place your code here.
-			_ = tt
+			err := Validate(tt.in)
+			require.NoError(t, err)
 		})
+	}
+}
+
+func TestNestedValidator(t *testing.T) {
+	role := Role{
+		ID:   325345634,
+		Name: "Oleg",
+		UUID: "b95b6a96-588a-4fcb-b169-0632a2c5bfc5",
+	}
+
+	userInfo := UserInfo{
+		ID:     105121255,
+		Role:   role,
+		Age:    25,
+		Phones: "57631726972",
+	}
+
+	userProfile := UserProfile{
+		ID:       "2bb24361-d0ef-426f-91d2-be42210390ed",
+		UserInfo: userInfo,
+		Identity: 11254343348,
+	}
+
+	t.Run("nested validation", func(t *testing.T) {
+		err := Validate(userProfile)
+		require.NoError(t, err)
+	})
+}
+
+func TestStructValidator(t *testing.T) {
+	t.Run("interface is not a struct", func(t *testing.T) {
+		tests := []struct {
+			in interface{}
+		}{
+			{in: "string"},
+			{in: 98},
+			{in: 12.23},
+			{in: []int{3, 4, 5}},
+		}
+
+		for i, tt := range tests {
+			t.Run(fmt.Sprintf("struct case %d", i), func(t *testing.T) {
+				err := Validate(tt.in)
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrNotStruct)
+			})
+		}
+	})
+}
+
+type ValidatorTest struct {
+	in            interface{}
+	expectedErr   error
+	expectedField string
+}
+
+func TestSimpleValidate(t *testing.T) {
+	tests := getStringTestParams()
+	tests = append(tests, getIntTestParams()...)
+	tests = append(tests, getSliceTestParams()...)
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("simple case %d", i), func(t *testing.T) {
+			err := Validate(tt.in)
+			if tt.expectedErr != nil {
+				var errs ValidationErrors
+				if errors.As(err, &errs) {
+					require.ErrorIs(t, errs[0].Err, tt.expectedErr)
+					require.Equal(t, errs[0].Field, tt.expectedField)
+				} else {
+					require.Fail(t, "test failed")
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type (
+	StringLen struct {
+		Len string `validate:"len:7"`
+	}
+
+	StringRegexp struct {
+		Regexp string `validate:"regexp:[0-9]+"`
+	}
+
+	StringIn struct {
+		In string `validate:"in:foo,bar"`
+	}
+
+	IntMin struct {
+		Min int `validate:"min:15"`
+	}
+
+	IntMax struct {
+		Max int `validate:"max:50"`
+	}
+
+	IntIn struct {
+		In int `validate:"in:1,2,3,4,5"`
+	}
+
+	StringSlice struct {
+		Strings []string `validate:"len:5|in:first,third"`
+	}
+
+	IntSlice struct {
+		Ints []int `validate:"min:1|max:50|in:5,10,15"`
+	}
+)
+
+func getStringTestParams() []ValidatorTest {
+	return []ValidatorTest{
+		{
+			in: StringLen{Len: "version"},
+		},
+		{
+			in:            StringLen{Len: "app"},
+			expectedErr:   ErrStringLength,
+			expectedField: "Len",
+		},
+		{
+			in: StringRegexp{Regexp: "23"},
+		},
+		{
+			in:            StringRegexp{Regexp: "version"},
+			expectedErr:   ErrStringNotMatchedRegexp,
+			expectedField: "Regexp",
+		},
+		{
+			in: StringIn{In: "foo"},
+		},
+		{
+			in:            StringIn{In: "version"},
+			expectedErr:   ErrStringNotIncludedSet,
+			expectedField: "In",
+		},
+	}
+}
+
+func getIntTestParams() []ValidatorTest {
+	return []ValidatorTest{
+		{
+			in: IntMin{Min: 15},
+		},
+		{
+			in:            IntMin{Min: 10},
+			expectedErr:   ErrIntLessThanMin,
+			expectedField: "Min",
+		},
+		{
+			in: IntMax{Max: 23},
+		},
+		{
+			in:            IntMax{Max: 51},
+			expectedErr:   ErrIntMoreThanMax,
+			expectedField: "Max",
+		},
+		{
+			in: IntIn{In: 2},
+		},
+		{
+			in:            IntIn{In: 10},
+			expectedErr:   ErrIntNotIncludedInSet,
+			expectedField: "In",
+		},
+	}
+}
+
+func getSliceTestParams() []ValidatorTest {
+	return []ValidatorTest{
+		{
+			in: StringSlice{Strings: []string{"first", "third"}},
+		},
+		{
+			in:            StringSlice{Strings: []string{"first", "thitt"}},
+			expectedErr:   ErrStringNotIncludedSet,
+			expectedField: "Strings",
+		},
+		{
+			in: IntSlice{Ints: []int{5, 10, 10, 15, 15, 15}},
+		},
+		{
+			in:            IntSlice{Ints: []int{0, 5, 10, 15}},
+			expectedErr:   ErrIntLessThanMin,
+			expectedField: "Ints",
+		},
 	}
 }

--- a/hw09_struct_validator/validator_test.go
+++ b/hw09_struct_validator/validator_test.go
@@ -149,7 +149,7 @@ func TestStructValidator(t *testing.T) {
 			t.Run(fmt.Sprintf("struct case %d", i), func(t *testing.T) {
 				err := Validate(tt.in)
 				require.Error(t, err)
-				require.ErrorIs(t, err, ErrNotStruct)
+				require.ErrorIs(t, err, ErrFailNotStruct)
 			})
 		}
 	})
@@ -293,6 +293,94 @@ func getSliceTestParams() []ValidatorTest {
 			in:            IntSlice{Ints: []int{0, 5, 10, 15}},
 			expectedErr:   ErrIntLessThanMin,
 			expectedField: "Ints",
+		},
+	}
+}
+
+func TestFailValidate(t *testing.T) {
+	tests := getStringFailParams()
+	tests = append(tests, getIntFailParams()...)
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("fail validate case %d", i), func(t *testing.T) {
+			err := Validate(tt.in)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+type (
+	StringWrongRule struct {
+		Wrong string `validate:"min:7"`
+	}
+
+	StringFailLen struct {
+		Len string `validate:"len:W7"`
+	}
+
+	StringFailRegexp struct {
+		Regexp string `validate:"regexp:stp("`
+	}
+
+	StringFailIn struct {
+		In string `validate:"in:"`
+	}
+
+	IntWrongRule struct {
+		Wrong int `validate:"len:7"`
+	}
+
+	IntFailMin struct {
+		Min int `validate:"min:w"`
+	}
+
+	IntFailMax struct {
+		Max int `validate:"max:r"`
+	}
+
+	IntFailIn struct {
+		In int `validate:"in:slice"`
+	}
+)
+
+func getStringFailParams() []ValidatorTest {
+	return []ValidatorTest{
+		{
+			in:          StringWrongRule{Wrong: "version"},
+			expectedErr: ErrFailWrongRule,
+		},
+		{
+			in:          StringFailLen{Len: "version"},
+			expectedErr: ErrFailWrongLengthNumber,
+		},
+		{
+			in:          StringFailRegexp{Regexp: "version"},
+			expectedErr: ErrFailWrongRegexp,
+		},
+		{
+			in:          StringFailIn{In: "version"},
+			expectedErr: ErrFailWrongSet,
+		},
+	}
+}
+
+func getIntFailParams() []ValidatorTest {
+	return []ValidatorTest{
+		{
+			in:          IntWrongRule{Wrong: 100},
+			expectedErr: ErrFailWrongRule,
+		},
+		{
+			in:          IntFailMin{Min: 100},
+			expectedErr: ErrFailWrongMinNumber,
+		},
+		{
+			in:          IntFailMax{Max: 100},
+			expectedErr: ErrFailWrongMaxNumber,
+		},
+		{
+			in:          IntFailIn{In: 100},
+			expectedErr: ErrFailSetNumber,
 		},
 	}
 }


### PR DESCRIPTION
## Домашнее задание №9 «Валидатор структур»

Необходимо реализовать функцию:
```golang
func Validate(v interface{}) error
```
Она должна валидировать публичные поля входной структуры на основе структурного тэга `validate`.

Функция может возвращать
- или программную ошибку, произошедшую во время валидации;
- или `ValidationErrors` - ошибку, являющуюся слайсом структур, содержащих имя поля и ошибку его валидации.

Таким образом, нужно накопить все ошибки валидации, а не прерывать валидацию на первой ошибке.

Если у поля нет структурных тэгов или нет тэга `validate`, то функция игнорирует его.

Типы полей, которые обязательно должны поддерживаться:
- `int`, `[]int`;
- `string`, `[]string`.

_При желании можно дополнительно поддержать любые другие типы (на ваше усмотрение)._

Необходимо реализовать следующие валидаторы:
- Для строк:
    * `len:32` - длина строки должна быть ровно 32 символа;
    * `regexp:\\d+` - согласно регулярному выражению строка должна состоять из цифр
    (`\\` - экранирование слэша);
    * `in:foo,bar` - строка должна входить в множество строк {"foo", "bar"}.
- Для чисел:
    * `min:10` - число не может быть меньше 10;
    * `max:20` - число не может быть больше 20;
    * `in:256,1024` - число должно входить в множество чисел {256, 1024};
- Для слайсов валидируется каждый элемент слайса.

_При желании можно дополнительно добавить парочку новых правил (на ваше усмотрение)._

Допускается комбинация валидаторов по логическому "И" с помощью `|`, например:
* `min:0|max:10` - число должно находится в пределах [0, 10];
* `regexp:\\d+|len:20` - строка должна состоять из цифр и иметь длину 20.

**(\*) Дополнительное задание: поддержка валидации вложенных по композиции структур.**
```golang
type User struct {
    m Meta `validate:"nested"`
}
```

### Критерии оценки
- Пайплайн зелёный - 3 балла
- Добавлены юнит-тесты - до 4 баллов
- Понятность и чистота кода - до 3 баллов
- Дополнительное задание на баллы не влияет

#### Зачёт от 7 баллов

### Подсказки
- `reflect.StructTag`
- `regexp.Compile`
- `errors.Is`

### Частые ошибки
- Отсутствует проверка на то, что входной `interface{}` - структура.
- Нет разделения на программные ошибки (неверный тэг, регулярка и пр.) и ошибки валидации.
- Ошибки валидации не вынесены в отдельные переменные и не завраплены.
- Соответственно в тестах не используется `errors.Is` / `errors.As`.